### PR TITLE
1.60

### DIFF
--- a/REVISION.TXT
+++ b/REVISION.TXT
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------
-Rev. 1.60 - 2014-01-01
-* 
+Rev. 1.60 - 2014-01-11
+* Fixed: File attribures parameter added in 1.50 ($extFileAttr) were not used in Zip->addFile.
+* Added: The ability to send the zip with a UTF-8 encoded filename, and the ability to choose to send the file as "inline"
+- Note, thanks to Mikael Ylikoski for these corrections and additions.
 ---------------------------------------------------------------------
 Rev. 1.50 - 2013-12-01
 * Added: Support for defining file permissions, using the unix format, ie. 644 for files and 755 for dirs

--- a/Zip.Example1.php
+++ b/Zip.Example1.php
@@ -29,5 +29,7 @@ if ($handle) {
 $zip->addDirectoryContent("testData/test", "recursiveDir/test");
 $zip->addDirectoryContent("testData/test", "recursiveDir/testFlat", FALSE);
 
-$zip->sendZip("ZipExample1.zip");
+//$zip->sendZip("ZipExample1.zip");
+//$zip->sendZip("ZipExample1_€2,000.zip");
+$zip->sendZip("ZipExample1_€2,000.zip", "application/zip", "ZipExample1_€2,000_utf8.zip");
 ?>

--- a/Zip.php
+++ b/Zip.php
@@ -236,7 +236,7 @@ class Zip {
             $this->zipflush();
         }
 
-        $this->buildZipEntry($filePath, $fileComment, $gpFlags, $gzType, $timestamp, $fileCRC32, $gzLength, $dataLength, self::EXT_FILE_ATTR_FILE);
+        $this->buildZipEntry($filePath, $fileComment, $gpFlags, $gzType, $timestamp, $fileCRC32, $gzLength, $dataLength, $extFileAttr);
 
         $this->zipwrite($gzData);
 
@@ -540,11 +540,13 @@ class Zip {
     /**
      * Send the archive as a zip download
      *
-     * @param string $fileName The name of the Zip archive, ie. "archive.zip".
-     * @param string $contentType Content mime type. Optional, defaults to "application/zip".
+     * @param String $fileName The name of the Zip archive, in ISO-8859-1 (or ASCII) encoding, ie. "archive.zip". Optional, defaults to NULL, which means that no ISO-8859-1 encoded file name will be specified.
+     * @param String $contentType Content mime type. Optional, defaults to "application/zip".
+     * @param String $utf8FileName The name of the Zip archive, in UTF-8 encoding. Optional, defaults to NULL, which means that no UTF-8 encoded file name will be specified.
+     * @param bool $inline Use Content-Disposition with "inline" instead of "attached". Optional, defaults to FALSE.
      * @return bool $success
      */
-    function sendZip($fileName, $contentType = "application/zip") {
+    function sendZip($fileName = null, $contentType = "application/zip", $utf8FileName = null, $inline = false) {
         if (!$this->isFinalized) {
             $this->finalize();
         }
@@ -552,7 +554,7 @@ class Zip {
         $headerFile = null;
         $headerLine = null;
         if (!headers_sent($headerFile, $headerLine) or die("<p><strong>Error:</strong> Unable to send file $fileName. HTML Headers have already been sent from <strong>$headerFile</strong> in line <strong>$headerLine</strong></p>")) {
-            if ((ob_get_contents() === FALSE || ob_get_contents() == '') or die("\n<p><strong>Error:</strong> Unable to send file <strong>$fileName.epub</strong>. Output buffer contains the following text (typically warnings or errors):<br>" . ob_get_contents() . "</p>")) {
+            if ((ob_get_contents() === FALSE || ob_get_contents() == '') or die("\n<p><strong>Error:</strong> Unable to send file <strong>$fileName</strong>. Output buffer contains the following text (typically warnings or errors):<br>" . htmlentities(ob_get_contents()) . "</p>")) {
                 if (ini_get('zlib.output_compression')) {
                     ini_set('zlib.output_compression', 'Off');
                 }
@@ -563,8 +565,19 @@ class Zip {
                 header("Accept-Ranges: bytes");
                 header("Connection: close");
                 header("Content-Type: " . $contentType);
-                header('Content-Disposition: attachment; filename="' . $fileName . '"');
-                header("Content-Transfer-Encoding: binary");
+                $cd = "Content-Disposition: ";
+                if ($inline) {
+                    $cd .= "inline";
+				} else{
+                    $cd .= "attached";
+				}
+                if ($fileName) {
+                    $cd .= '; filename="' . $fileName . '"';
+				}
+                if ($utf8FileName) {
+                    $cd .= "; filename*=UTF-8''" . rawurlencode($utf8FileName);
+				}
+                header($cd);
                 header("Content-Length: ". $this->getArchiveSize());
 
                 if (!is_resource($this->zipFile)) {

--- a/ZipStream.Example1s.php
+++ b/ZipStream.Example1s.php
@@ -16,7 +16,9 @@ $chapter1 = "Chapter 1\n"
 . "Lorem ipsum\n"
 . "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n";
 
-$zip = new ZipStream("ZipStreamExample1s.zip");
+//$zip = new ZipStream("ZipStreamExample1s.zip");
+//$zip = new ZipStream("ZipStreamExample1s_€2,000.zip");
+$zip = new ZipStream("ZipStreamExample1s_€2,000.zip", "application/zip", "ZipStreamExample1s_€2,000_utf8.zip");
 
 $zip->setComment("Example Zip file for Large file sets.\nCreated on " . date('l jS \of F Y h:i:s A'));
 

--- a/ZipStream.Example2s.php
+++ b/ZipStream.Example2s.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * A test to see if it was possible to recreate the result of
+ *  Issue #7, if not the cause.
+ * And a demnostration why the author of the script calling zip
+ *  needs to be dilligent not to add extra characters to the output.
+ */
+include_once("ZipStream.php");
+
+$zip = new ZipStream("test.zip");
+
+/*
+ * As seen in the output, the above construct with a PHP end and start tag after
+ * creating the ZipStream is a bad idea. The Zip file will be starting with a
+ * space followed by the newline characters.
+ */
+$zip->addDirectory("test");
+$zip->addDirectoryContent("testData/test","test");
+return $zip->finalize();
+
+?>

--- a/ZipStream.php
+++ b/ZipStream.php
@@ -93,10 +93,12 @@ class ZipStream {
     /**
      * Constructor.
      *
-     * @param string $archiveName Name to send to the HTTP client.
-     * @param string $contentType Content mime type. Optional, defaults to "application/zip".
+     * @param String $fileName The name of the Zip archive, in ISO-8859-1 (or ASCII) encoding, ie. "archive.zip". Optional, defaults to NULL, which means that no ISO-8859-1 encoded file name will be specified.
+     * @param String $contentType Content mime type. Optional, defaults to "application/zip".
+     * @param String $utf8FileName The name of the Zip archive, in UTF-8 encoding. Optional, defaults to NULL, which means that no UTF-8 encoded file name will be specified.
+     * @param bool $inline Use Content-Disposition with "inline" instead of "attached". Optional, defaults to FALSE.
      */
-    function __construct($archiveName = "", $contentType = "application/zip") {
+    function __construct($archiveName = "", $contentType = "application/zip", $utf8FileName = null, $inline = false) {
         if (!function_exists('sys_get_temp_dir')) {
             die ("ERROR: ZipStream " . self::VERSION . " requires PHP version 5.2.1 or above.");
         }
@@ -115,9 +117,20 @@ class ZipStream {
                 header("Accept-Ranges: bytes");
                 //header("Connection: Keep-Alive");
                 header("Content-Type: " . $contentType);
-                header('Content-Disposition: attachment; filename="' . $archiveName . '"');
-                header("Content-Transfer-Encoding: binary");
-                flush();
+                $cd = "Content-Disposition: ";
+                if ($inline) {
+                    $cd .= "inline";
+				} else{
+                    $cd .= "attached";
+				}
+                if ($fileName) {
+                    $cd .= '; filename="' . $fileName . '"';
+				}
+                if ($utf8FileName) {
+                    $cd .= "; filename*=UTF-8''" . rawurlencode($utf8FileName);
+				}
+                header($cd);
+				flush();
             }
         }
     }


### PR DESCRIPTION
- Fixed: File attribures parameter added in 1.50 ($extFileAttr) were not used in Zip->addFile.
- Added: The ability to send the zip with a UTF-8 encoded filename, and the ability to choose to send the file as "inline"
- Note, thanks to Mikael Ylikoski for these corrections and additions.
