### PR TITLE
Allow customizing temporary file names

### DIFF
--- a/Zip.php
+++ b/Zip.php
@@ -92,6 +92,11 @@ class Zip {
     private $streamData = NULL;
     private $streamFileLength = 0;
 	private $streamExtFileAttr = null;
+	/**
+	 * A custom temporary folder, or a callable that returns a custom temporary file.
+	 * @var string|callable
+	 */
+	public static $temp = null;
 
     /**
      * Constructor.
@@ -360,7 +365,7 @@ class Zip {
             $this->closeStream();
         }
 
-        $this->streamFile = tempnam(sys_get_temp_dir(), 'Zip');
+        $this->streamFile = self::getTemporaryFile();
         $this->streamData = fopen($this->streamFile, "wb");
         $this->streamFilePath = $filePath;
         $this->streamTimestamp = $timestamp;
@@ -426,7 +431,7 @@ class Zip {
             return FALSE;
         }
 
-        $tempzip = tempnam(sys_get_temp_dir(), 'ZipStream');
+        $tempzip = self::getTemporaryFile();
 
         $zip = new ZipArchive;
         if ($zip->open($tempzip) === TRUE) {
@@ -838,5 +843,19 @@ class Zip {
 		}
 		return FALSE;
 	}
+	/**
+	 * Returns the path to a temporary file.
+	 * @return string
+	 */
+	private static function getTemporaryFile() {
+		if(is_callable(self::$temp)) {
+			$temporaryFile = @call_user_func(self::$temp);
+			if(is_string($temporaryFile) && strlen($temporaryFile)) {
+				return $temporaryFile;
+			}
+		}
+		$temporaryDirectory = (is_string(self::$temp) && strlen(self::$temp)) ? self::$temp : sys_get_temp_dir();
+		return tempnam($temporaryDirectory, 'Zip');
+	}
 }
-?>
+


### PR DESCRIPTION
Let's allow users to customize temporary files, either by setting `Zip::$temp` to a custom temporary folder or by setting `Zip::$temp` to a callable that returns a custom temporary file name.

Supersedes https://github.com/Grandt/PHPZip/pull/20
