### PR TITLE
Fix attributes and const uses

### DIFF
--- a/src/Zip/File/Zip.php
+++ b/src/Zip/File/Zip.php
@@ -287,7 +287,7 @@ class Zip extends \PHPZip\Zip\Core\AbstractZipArchive {
      * @param int $gzLength length of the pending data.
      */
     public function zipVerifyMemBuffer($gzLength) {
-        if (!is_resource($this->zipFile) && ($this->offset + $gzLength) > $this->zipMemoryThreshold) {
+        if (!is_resource($this->_zipFile) && ($this->offset + $gzLength) > self::MEMORY_THRESHOLD) {
             $this->zipFlush();
         }
     }
@@ -299,11 +299,11 @@ class Zip extends \PHPZip\Zip\Core\AbstractZipArchive {
      * @param string $data
      */
     public function zipWrite($data) {
-        if (!is_resource($this->zipFile)) {
-            $this->zipData .= $data;
+        if (!is_resource($this->_zipFile)) {
+            $this->_zipData .= $data;
         } else {
-            fwrite($this->zipFile, $data);
-            fflush($this->zipFile);
+            fwrite($this->_zipFile, $data);
+            fflush($this->_zipFile);
         }
     }
 
@@ -314,10 +314,10 @@ class Zip extends \PHPZip\Zip\Core\AbstractZipArchive {
      *
      */
     public function zipFlush() {
-        if (!is_resource($this->zipFile)) {
-            $this->zipFile = tmpfile();
-            fwrite($this->zipFile, $this->zipData);
-            $this->zipData = null;
+        if (!is_resource($this->_zipFile)) {
+            $this->_zipFile = tmpfile();
+            fwrite($this->_zipFile, $this->_zipData);
+            $this->_zipData = null;
         }
     }
 


### PR DESCRIPTION
Thanks for this helpful package. I'm so happy to get zip support when I can't Install ZipArchive extension in my shared web hosting.

I use your 2.00 version. And there were errors when I tested. Here is small fix, looks like you forget to change the attributes?
